### PR TITLE
glusterd: volume info should not show "feature.scrub: resume" if scrub r...

### DIFF
--- a/tests/bugs/bitrot/1209818-vol-info-show-scrub-process-properly.t
+++ b/tests/bugs/bitrot/1209818-vol-info-show-scrub-process-properly.t
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+## Test case for bitrot.
+## volume info should not show 'features.scrub: resume' if scrub process is
+## resumed from paused state.
+
+
+. $(dirname $0)/../../include.rc
+. $(dirname $0)/../../volume.rc
+. $(dirname $0)/../../cluster.rc
+
+cleanup;
+
+## Start glusterd
+TEST glusterd;
+TEST pidof glusterd;
+
+## Lets create and start the volume
+TEST $CLI volume create $V0 $H0:$B0/${V0}0 $H0:$B0/${V0}1
+TEST $CLI volume start $V0
+
+## Enable bitrot on volume $V0
+TEST $CLI volume bitrot $V0 enable
+
+## Set bitrot scrubber process to pause state
+TEST $CLI volume bitrot $V0 scrub pause
+
+## gluster volume info command should show scrub process pause.
+EXPECT 'pause' volinfo_field $V0 'features.scrub';
+
+
+## Resume scrub process on volume $V0
+TEST $CLI volume bitrot $V0 scrub resume
+
+## gluster volume info command should show scrub process Active
+EXPECT 'Active' volinfo_field $V0 'features.scrub';
+
+
+## Disable bitrot on volume $V0
+TEST $CLI volume bitrot $V0 disable
+
+## gluster volume info command should show scrub process Inactive
+EXPECT 'Inactive' volinfo_field $V0 'features.scrub';
+
+
+cleanup;


### PR DESCRIPTION
...esumed

If bitrot is enable on the volume and if user paused the scrub process and then
resume the scrub process then command #gluster volume info <VOLNAME> should show
status of option features.scrub: Active.

If bitrot is enable on the volume and user disable the bitrot on the volume then
command #gluster volume info <VOLNAME> should show status of option
features.scrub: Inactive.

If bitrot is enable on the volume and user paused the scrub porcess then command
gluster volume info <VOLNAME> should show the status of option
features.scrub: pause.

Change-Id: I55972eef3b8570b7cb05dc28700d4e28dc45a86a
BUG: 1209818
Signed-off-by: Gaurav Kumar Garg ggarg@redhat.com
